### PR TITLE
Remove imgops from GR

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -6,7 +6,6 @@ ftp-watcher: sbt -Dftp.active=true "project ftp-watcher" "~ run 9004"
 kahuna: sbt "project kahuna" "~ run 9005"
 cropper: sbt "project cropper" "~ run 9006"
 metadata-editor: sbt "project metadata-editor" "~ run 9007"
-imgops: cd imgops; ./dev-start.sh
 usage: sbt "project usage" "~ run 9009"
 collections: sbt "project collections" "~ run 9010"
 auth: sbt "project auth" "~ run 9011"

--- a/lib/grid_runner/applications.rb
+++ b/lib/grid_runner/applications.rb
@@ -2,7 +2,7 @@ require 'open3'
 
 class App
   PROCFILE = File.open(Dir.pwd + "/Procfile")
-  
+
   attr_reader :name, :command, :status, :pid
 
   def initialize(name, command, status, pid)
@@ -35,7 +35,7 @@ class App
 
   def display(color_index = rand(0..COLORS.length))
     puts
-    puts Rainbow("#{name} ").send(COLORS[color_index % COLORS.length]).underline 
+    puts Rainbow("#{name} ").send(COLORS[color_index % COLORS.length]).underline
     puts "status: #{status}"
     puts "pid: #{pid}" if status == :running
     puts "log: #{log.path}"
@@ -59,8 +59,8 @@ class App
 
     Process.spawn(
       ENV,
-      command, 
-      out: [log.path, "w"], 
+      command,
+      out: [log.path, "w"],
       err: [log.path, "w"],
       :in => "/dev/null"
       )
@@ -73,12 +73,12 @@ class App
   private
 
   def self.app_process_from_grep(stdout, name = nil)
-    stdout.split(/\n/).find do |l| 
-      l.match(name) && 
-      !l.match("grep") && 
+    stdout.split(/\n/).find do |l|
+      l.match(name) &&
+      !l.match("grep") &&
       !l.match("tail") &&
-      # for auth 
-      !l.match("MacOS") && 
+      # for auth
+      !l.match("MacOS") &&
       !l.match("grid_runner")
     end
   end


### PR DESCRIPTION
As per https://github.com/guardian/grid/pull/1805
Removing imgops from Grid runner as it's shifted to global nginx.

A lot of these changes are atom's whitespace removal.